### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2017 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@link https://github.com/localheinz/factory-girl-definition
+@link https://github.com/ergebnis/factory-girl-definition
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.3.0...master`][1.3.0...master]
+For a full diff see [`2.0.0...master`][2.0.0...master]
+
+## [`2.0.0`][2.0.0]
+
+For a full diff see [`1.3.0...2.0.0`][1.3.0...2.0.0].
 
 ### Changed
 
 * Added return type declarations ([#71]), by [@localheinz]
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#73]), by [@localheinz]
+
+  Run
+
+  ```
+  $ composer remove localheinz/factory-girl-definition
+  ```
+
+  and
+
+  ```
+  $ composer require ergebnis/factory-girl-definition
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Localheinz\\FactoryGirl\\Definition/Ergebnis\\FactoryGirl\\Definition/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\FactoryGirl\Definition` with `Ergebnis\FactoryGirl\Definition`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
 
 ### Fixed
 
@@ -56,27 +91,31 @@ For a full diff see [`740095e...0.1.0`][740095e...0.1.0].
 
 * Added interface and finder ([#1]), by [@localheinz]
 
-[0.1.0]: https://github.com/localheinz/factory-girl-definition/tag/0.1.0
-[0.1.1]: https://github.com/localheinz/factory-girl-definition/tag/0.1.1
-[0.2.0]: https://github.com/localheinz/factory-girl-definition/tag/0.2.0
-[1.0.0]: https://github.com/localheinz/factory-girl-definition/tag/1.0.0
-[1.1.0]: https://github.com/localheinz/factory-girl-definition/tag/1.1.0
-[1.2.0]: https://github.com/localheinz/factory-girl-definition/tag/1.2.0
-[1.3.0]: https://github.com/localheinz/factory-girl-definition/tag/1.3.0
+[0.1.0]: https://github.com/ergebnis/factory-girl-definition/tag/0.1.0
+[0.1.1]: https://github.com/ergebnis/factory-girl-definition/tag/0.1.1
+[0.2.0]: https://github.com/ergebnis/factory-girl-definition/tag/0.2.0
+[1.0.0]: https://github.com/ergebnis/factory-girl-definition/tag/1.0.0
+[1.1.0]: https://github.com/ergebnis/factory-girl-definition/tag/1.1.0
+[1.2.0]: https://github.com/ergebnis/factory-girl-definition/tag/1.2.0
+[1.3.0]: https://github.com/ergebnis/factory-girl-definition/tag/1.3.0
+[2.0.0]: https://github.com/ergebnis/factory-girl-definition/tag/2.0.0
 
-[740095e...0.1.0]: https://github.com/localheinz/factory-girl-definition/compare/740095e...0.1.0
-[0.1.0...0.1.1]: https://github.com/localheinz/factory-girl-definition/compare/0.1.0...0.1.1
-[0.1.1...0.2.0]: https://github.com/localheinz/factory-girl-definition/compare/0.1.1...0.2.0
-[0.2.0...1.0.0]: https://github.com/localheinz/factory-girl-definition/compare/0.2.0...1.0.0
-[1.0.0...1.1.0]: https://github.com/localheinz/factory-girl-definition/compare/1.0.0...1.1.0
-[1.1.0...1.2.0]: https://github.com/localheinz/factory-girl-definition/compare/1.1.0...1.2.0
-[1.2.0...1.3.0]: https://github.com/localheinz/factory-girl-definition/compare/1.1.0...1.3.0
-[1.3.0...master]: https://github.com/localheinz/factory-girl-definition/compare/1.3.0...master
+[740095e...0.1.0]: https://github.com/ergebnis/factory-girl-definition/compare/740095e...0.1.0
+[0.1.0...0.1.1]: https://github.com/ergebnis/factory-girl-definition/compare/0.1.0...0.1.1
+[0.1.1...0.2.0]: https://github.com/ergebnis/factory-girl-definition/compare/0.1.1...0.2.0
+[0.2.0...1.0.0]: https://github.com/ergebnis/factory-girl-definition/compare/0.2.0...1.0.0
+[1.0.0...1.1.0]: https://github.com/ergebnis/factory-girl-definition/compare/1.0.0...1.1.0
+[1.1.0...1.2.0]: https://github.com/ergebnis/factory-girl-definition/compare/1.1.0...1.2.0
+[1.2.0...1.3.0]: https://github.com/ergebnis/factory-girl-definition/compare/1.1.0...1.3.0
+[1.3.0...2.0.0]: https://github.com/ergebnis/factory-girl-definition/compare/1.3.0...2.0.0
+[2.0.0...master]: https://github.com/ergebnis/factory-girl-definition/compare/2.0.0...master
 
-[#1]: https://github.com/localheinz/factory-girl-definition/pull/1
-[#3]: https://github.com/localheinz/factory-girl-definition/pull/3
-[#4]: https://github.com/localheinz/factory-girl-definition/pull/4
-[#69]: https://github.com/localheinz/factory-girl-definition/pull/69
-[#71]: https://github.com/localheinz/factory-girl-definition/pull/71
+[#1]: https://github.com/ergebnis/factory-girl-definition/pull/1
+[#3]: https://github.com/ergebnis/factory-girl-definition/pull/3
+[#4]: https://github.com/ergebnis/factory-girl-definition/pull/4
+[#69]: https://github.com/ergebnis/factory-girl-definition/pull/69
+[#71]: https://github.com/ergebnis/factory-girl-definition/pull/71
+[#73]: https://github.com/ergebnis/factory-girl-definition/pull/73
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # factory-girl-definition
 
-[![Continuous Integration](https://github.com/localheinz/factory-girl-definition/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/factory-girl-definition/actions)
-[![Code Coverage](https://codecov.io/gh/localheinz/factory-girl-definition/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/factory-girl-definition)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/factory-girl-definition/v/stable)](https://packagist.org/packages/localheinz/factory-girl-definition)
-[![Total Downloads](https://poser.pugx.org/localheinz/factory-girl-definition/downloads)](https://packagist.org/packages/localheinz/factory-girl-definition)
+[![Continuous Integration](https://github.com/ergebnis/factory-girl-definition/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/factory-girl-definition/actions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/factory-girl-definition/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/factory-girl-definition)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/factory-girl-definition/v/stable)](https://packagist.org/packages/ergebnis/factory-girl-definition)
+[![Total Downloads](https://poser.pugx.org/ergebnis/factory-girl-definition/downloads)](https://packagist.org/packages/ergebnis/factory-girl-definition)
 
 Provides an interface for, and an easy way to find and register entity definitions for [`breerly/factory-girl-php`](https://github.com/breerly/factory-girl-php).
 
@@ -12,7 +12,7 @@ Provides an interface for, and an easy way to find and register entity definitio
 Run
 
 ```
-$ composer require --dev localheinz/factory-girl-definition
+$ composer require --dev ergebnis/factory-girl-definition
 ```
 
 ## Usage
@@ -21,8 +21,8 @@ $ composer require --dev localheinz/factory-girl-definition
 
 Implement one of the
 
-* `Localheinz\FactoryGirl\Definition\Definition`
-* `Localheinz\FactoryGirl\Definition\FakerAwareDefinition`
+* `Ergebnis\FactoryGirl\Definition\Definition`
+* `Ergebnis\FactoryGirl\Definition\FakerAwareDefinition`
 
 interfaces and use the instance of `FactoryGirl\Provider\Doctrine\FixtureFactory`
 that is passed into `accept()` to define entities:
@@ -32,9 +32,9 @@ that is passed into `accept()` to define entities:
 
 namespace Foo\Bar\Test\Fixture\Entity;
 
+use Ergebnis\FactoryGirl\Definition\Definition;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Foo\Bar\Entity;
-use Localheinz\FactoryGirl\Definition\Definition;
 
 final class UserDefinition implements Definition
 {
@@ -63,9 +63,9 @@ fixture factory, and optionally provide definitions with an instance of
 namespace Foo\Bar\Test\Integration;
 
 use Doctrine\ORM;
+use Ergebnis\FactoryGirl\Definition\Definitions;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Faker\Generator;
-use Localheinz\FactoryGirl\Definition\Definitions;
 use PHPUnit\Framework;
 
 abstract class AbstractIntegrationTestCase extends Framework\TestCase

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "localheinz/factory-girl-definition",
+  "name": "ergebnis/factory-girl-definition",
   "type": "library",
   "description": "Provides an interface for, and an easy way to find and register entity definitions for breerly/factory-girl-php.",
-  "homepage": "https://github.com/localheinz/factory-girl-definition",
+  "homepage": "https://github.com/ergebnis/factory-girl-definition",
   "license": "MIT",
   "authors": [
     {
@@ -15,6 +15,9 @@
     "breerly/factory-girl-php": "^1.0.3",
     "ergebnis/classy": "~0.5.0",
     "fzaninotto/faker": "^1.9.0"
+  },
+  "replace": {
+    "localheinz/factory-girl-definition": "*"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.0.0",
@@ -38,16 +41,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\FactoryGirl\\Definition\\": "src"
+      "Ergebnis\\FactoryGirl\\Definition\\": "src"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\FactoryGirl\\Definition\\Test\\": "test"
+      "Ergebnis\\FactoryGirl\\Definition\\Test\\": "test"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/factory-girl-definition/issues",
-    "source": "https://github.com/localheinz/factory-girl-definition"
+    "issues": "https://github.com/ergebnis/factory-girl-definition/issues",
+    "source": "https://github.com/ergebnis/factory-girl-definition"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ab83cacfd2f3ad57d039d977b4b6407",
+    "content-hash": "17f6c48b09d5ff26f73918ef43ca06a1",
     "packages": [
         {
             "name": "breerly/factory-girl-php",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,8 +4,8 @@ includes:
 parameters:
 	ergebnis:
 		classesAllowedToBeExtended:
+			- Ergebnis\FactoryGirl\Definition\AbstractDefinition
 			- InvalidArgumentException
-			- Localheinz\FactoryGirl\Definition\AbstractDefinition
 			- RuntimeException
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max

--- a/src/AbstractDefinition.php
+++ b/src/AbstractDefinition.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition;
+namespace Ergebnis\FactoryGirl\Definition;
 
 use Faker\Generator;
 

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition;
+namespace Ergebnis\FactoryGirl\Definition;
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition;
+namespace Ergebnis\FactoryGirl\Definition;
 
 use Ergebnis\Classy;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;

--- a/src/Exception/InvalidDefinition.php
+++ b/src/Exception/InvalidDefinition.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Exception;
+namespace Ergebnis\FactoryGirl\Definition\Exception;
 
 final class InvalidDefinition extends \RuntimeException
 {

--- a/src/Exception/InvalidDirectory.php
+++ b/src/Exception/InvalidDirectory.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Exception;
+namespace Ergebnis\FactoryGirl\Definition\Exception;
 
 final class InvalidDirectory extends \InvalidArgumentException
 {

--- a/src/FakerAwareDefinition.php
+++ b/src/FakerAwareDefinition.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition;
+namespace Ergebnis\FactoryGirl\Definition;
 
 use Faker\Generator;
 

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\AutoReview;
+namespace Ergebnis\FactoryGirl\Definition\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\FactoryGirl\\Definition\\',
-            'Localheinz\\FactoryGirl\\Definition\\Test\\Unit\\'
+            'Ergebnis\\FactoryGirl\\Definition\\',
+            'Ergebnis\\FactoryGirl\\Definition\\Test\\Unit\\'
         );
     }
 }

--- a/test/Fixture/Definition/Acceptable/UserDefinition.php
+++ b/test/Fixture/Definition/Acceptable/UserDefinition.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\Acceptable;
+namespace Ergebnis\FactoryGirl\Definition\Test\Fixture\Definition\Acceptable;
 
+use Ergebnis\FactoryGirl\Definition\Definition;
+use Ergebnis\FactoryGirl\Definition\Test\Fixture\Entity;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
-use Localheinz\FactoryGirl\Definition\Definition;
-use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 /**
  * Is acceptable as it implements the interface.

--- a/test/Fixture/Definition/DoesNotImplementInterface/UserDefinition.php
+++ b/test/Fixture/Definition/DoesNotImplementInterface/UserDefinition.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\DoesNotImplementInterface;
+namespace Ergebnis\FactoryGirl\Definition\Test\Fixture\Definition\DoesNotImplementInterface;
 
+use Ergebnis\FactoryGirl\Definition\Test\Fixture\Entity;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
-use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it does not implement the DefinitionInterface.

--- a/test/Fixture/Definition/ExtendsAbstractDefinition/UserDefinition.php
+++ b/test/Fixture/Definition/ExtendsAbstractDefinition/UserDefinition.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\ExtendsAbstractDefinition;
+namespace Ergebnis\FactoryGirl\Definition\Test\Fixture\Definition\ExtendsAbstractDefinition;
 
+use Ergebnis\FactoryGirl\Definition\AbstractDefinition;
+use Ergebnis\FactoryGirl\Definition\Test\Fixture\Entity;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
-use Localheinz\FactoryGirl\Definition\AbstractDefinition;
-use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 final class UserDefinition extends AbstractDefinition
 {

--- a/test/Fixture/Definition/FakerAware/GroupDefinition.php
+++ b/test/Fixture/Definition/FakerAware/GroupDefinition.php
@@ -8,15 +8,15 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\FakerAware;
+namespace Ergebnis\FactoryGirl\Definition\Test\Fixture\Definition\FakerAware;
 
+use Ergebnis\FactoryGirl\Definition\FakerAwareDefinition;
+use Ergebnis\FactoryGirl\Definition\Test\Fixture\Entity;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Faker\Generator;
-use Localheinz\FactoryGirl\Definition\FakerAwareDefinition;
-use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 final class GroupDefinition implements FakerAwareDefinition
 {

--- a/test/Fixture/Definition/FakerAware/UserDefinition.php
+++ b/test/Fixture/Definition/FakerAware/UserDefinition.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\FakerAware;
+namespace Ergebnis\FactoryGirl\Definition\Test\Fixture\Definition\FakerAware;
 
+use Ergebnis\FactoryGirl\Definition\Definition;
+use Ergebnis\FactoryGirl\Definition\Test\Fixture\Entity;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
-use Localheinz\FactoryGirl\Definition\Definition;
-use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 final class UserDefinition implements Definition
 {

--- a/test/Fixture/Definition/IsAbstract/UserDefinition.php
+++ b/test/Fixture/Definition/IsAbstract/UserDefinition.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\IsAbstract;
+namespace Ergebnis\FactoryGirl\Definition\Test\Fixture\Definition\IsAbstract;
 
+use Ergebnis\FactoryGirl\Definition\Definition;
+use Ergebnis\FactoryGirl\Definition\Test\Fixture\Entity;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
-use Localheinz\FactoryGirl\Definition\Definition;
-use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it is abstract.

--- a/test/Fixture/Definition/PrivateConstructor/UserDefinition.php
+++ b/test/Fixture/Definition/PrivateConstructor/UserDefinition.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\PrivateConstructor;
+namespace Ergebnis\FactoryGirl\Definition\Test\Fixture\Definition\PrivateConstructor;
 
+use Ergebnis\FactoryGirl\Definition\Definition;
+use Ergebnis\FactoryGirl\Definition\Test\Fixture\Entity;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
-use Localheinz\FactoryGirl\Definition\Definition;
-use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it has a private constructor.

--- a/test/Fixture/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
+++ b/test/Fixture/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\ThrowsExceptionDuringConstruction;
+namespace Ergebnis\FactoryGirl\Definition\Test\Fixture\Definition\ThrowsExceptionDuringConstruction;
 
+use Ergebnis\FactoryGirl\Definition\Definition;
+use Ergebnis\FactoryGirl\Definition\Test\Fixture\Entity;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
-use Localheinz\FactoryGirl\Definition\Definition;
-use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it throws an exception during construction.

--- a/test/Fixture/Entity/Group.php
+++ b/test/Fixture/Entity/Group.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
+namespace Ergebnis\FactoryGirl\Definition\Test\Fixture\Entity;
 
 final class Group
 {

--- a/test/Fixture/Entity/User.php
+++ b/test/Fixture/Entity/User.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
+namespace Ergebnis\FactoryGirl\Definition\Test\Fixture\Entity;
 
 final class User
 {

--- a/test/Unit/AbstractDefinitionTest.php
+++ b/test/Unit/AbstractDefinitionTest.php
@@ -8,22 +8,22 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit;
+namespace Ergebnis\FactoryGirl\Definition\Test\Unit;
 
+use Ergebnis\FactoryGirl\Definition\AbstractDefinition;
+use Ergebnis\FactoryGirl\Definition\FakerAwareDefinition;
+use Ergebnis\FactoryGirl\Definition\Test\Fixture;
 use Ergebnis\Test\Util\Helper;
 use Faker\Generator;
-use Localheinz\FactoryGirl\Definition\AbstractDefinition;
-use Localheinz\FactoryGirl\Definition\FakerAwareDefinition;
-use Localheinz\FactoryGirl\Definition\Test\Fixture;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\FactoryGirl\Definition\AbstractDefinition
+ * @covers \Ergebnis\FactoryGirl\Definition\AbstractDefinition
  */
 final class AbstractDefinitionTest extends Framework\TestCase
 {

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -8,28 +8,28 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit;
+namespace Ergebnis\FactoryGirl\Definition\Test\Unit;
 
+use Ergebnis\FactoryGirl\Definition\Definition;
+use Ergebnis\FactoryGirl\Definition\Definitions;
+use Ergebnis\FactoryGirl\Definition\Exception;
+use Ergebnis\FactoryGirl\Definition\FakerAwareDefinition;
+use Ergebnis\FactoryGirl\Definition\Test\Fixture;
 use Ergebnis\Test\Util\Helper;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Faker\Generator;
-use Localheinz\FactoryGirl\Definition\Definition;
-use Localheinz\FactoryGirl\Definition\Definitions;
-use Localheinz\FactoryGirl\Definition\Exception;
-use Localheinz\FactoryGirl\Definition\FakerAwareDefinition;
-use Localheinz\FactoryGirl\Definition\Test\Fixture;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\FactoryGirl\Definition\Definitions
+ * @covers \Ergebnis\FactoryGirl\Definition\Definitions
  *
- * @uses \Localheinz\FactoryGirl\Definition\Exception\InvalidDefinition
- * @uses \Localheinz\FactoryGirl\Definition\Exception\InvalidDirectory
+ * @uses \Ergebnis\FactoryGirl\Definition\Exception\InvalidDefinition
+ * @uses \Ergebnis\FactoryGirl\Definition\Exception\InvalidDirectory
  */
 final class DefinitionsTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/InvalidDefinitionTest.php
+++ b/test/Unit/Exception/InvalidDefinitionTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit\Exception;
+namespace Ergebnis\FactoryGirl\Definition\Test\Unit\Exception;
 
+use Ergebnis\FactoryGirl\Definition\Exception;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\FactoryGirl\Definition\Exception;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\FactoryGirl\Definition\Exception\InvalidDefinition
+ * @covers \Ergebnis\FactoryGirl\Definition\Exception\InvalidDefinition
  */
 final class InvalidDefinitionTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/InvalidDirectoryTest.php
+++ b/test/Unit/Exception/InvalidDirectoryTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit\Exception;
+namespace Ergebnis\FactoryGirl\Definition\Test\Unit\Exception;
 
+use Ergebnis\FactoryGirl\Definition\Exception;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\FactoryGirl\Definition\Exception;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\FactoryGirl\Definition\Exception\InvalidDirectory
+ * @covers \Ergebnis\FactoryGirl\Definition\Exception\InvalidDirectory
  */
 final class InvalidDirectoryTest extends Framework\TestCase
 {

--- a/test/Unit/FakerAwareDefinitionTest.php
+++ b/test/Unit/FakerAwareDefinitionTest.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/factory-girl-definition
+ * @link https://github.com/ergebnis/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit;
+namespace Ergebnis\FactoryGirl\Definition\Test\Unit;
 
+use Ergebnis\FactoryGirl\Definition\Definition;
+use Ergebnis\FactoryGirl\Definition\FakerAwareDefinition;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\FactoryGirl\Definition\Definition;
-use Localheinz\FactoryGirl\Definition\FakerAwareDefinition;
 use PHPUnit\Framework;
 
 /**


### PR DESCRIPTION
This PR

* [x] renames the vendor namespace `Localheinz` to `Ergebnis` after the move to @ergebnis