### PR TITLE
Fix: Add return type declaration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ use Foo\Bar\Entity;
 
 final class UserDefinition implements Definition
 {
-    public function accept(FixtureFactory $fixtureFactory)
+    public function accept(FixtureFactory $fixtureFactory): void
     {
         $fixtureFactory->defineEntity(Entity\User::class, [
             // ...


### PR DESCRIPTION
This PR

* [x] adds return type declarations in `README.md`

Follows #71.