### PR TITLE
Fix: Remove inappropriate replace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.0.0...master`][2.0.0...master]
+For a full diff see [`2.0.1...master`][2.0.1...master]
+
+## [`2.0.1`][2.0.1]
+
+For a full diff see [`2.0.0...2.0.1`][2.0.0...2.0.1].
+
+### Fixed
+
+* Removed an inappropriate `replace` configuration from `composer.json` ([#76]), by [@localheinz]
 
 ## [`2.0.0`][2.0.0]
 
@@ -99,6 +107,7 @@ For a full diff see [`740095e...0.1.0`][740095e...0.1.0].
 [1.2.0]: https://github.com/ergebnis/factory-girl-definition/tag/1.2.0
 [1.3.0]: https://github.com/ergebnis/factory-girl-definition/tag/1.3.0
 [2.0.0]: https://github.com/ergebnis/factory-girl-definition/tag/2.0.0
+[2.0.1]: https://github.com/ergebnis/factory-girl-definition/tag/2.0.1
 
 [740095e...0.1.0]: https://github.com/ergebnis/factory-girl-definition/compare/740095e...0.1.0
 [0.1.0...0.1.1]: https://github.com/ergebnis/factory-girl-definition/compare/0.1.0...0.1.1
@@ -108,7 +117,8 @@ For a full diff see [`740095e...0.1.0`][740095e...0.1.0].
 [1.1.0...1.2.0]: https://github.com/ergebnis/factory-girl-definition/compare/1.1.0...1.2.0
 [1.2.0...1.3.0]: https://github.com/ergebnis/factory-girl-definition/compare/1.1.0...1.3.0
 [1.3.0...2.0.0]: https://github.com/ergebnis/factory-girl-definition/compare/1.3.0...2.0.0
-[2.0.0...master]: https://github.com/ergebnis/factory-girl-definition/compare/2.0.0...master
+[2.0.0...2.0.1]: https://github.com/ergebnis/factory-girl-definition/compare/2.0.0...2.0.1
+[2.0.1...master]: https://github.com/ergebnis/factory-girl-definition/compare/2.0.1...master
 
 [#1]: https://github.com/ergebnis/factory-girl-definition/pull/1
 [#3]: https://github.com/ergebnis/factory-girl-definition/pull/3
@@ -116,6 +126,7 @@ For a full diff see [`740095e...0.1.0`][740095e...0.1.0].
 [#69]: https://github.com/ergebnis/factory-girl-definition/pull/69
 [#71]: https://github.com/ergebnis/factory-girl-definition/pull/71
 [#73]: https://github.com/ergebnis/factory-girl-definition/pull/73
+[#76]: https://github.com/ergebnis/factory-girl-definition/pull/76
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,6 @@
     "ergebnis/classy": "~0.5.0",
     "fzaninotto/faker": "^1.9.0"
   },
-  "replace": {
-    "localheinz/factory-girl-definition": "*"
-  },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.0.0",
     "ergebnis/phpstan-rules": "~0.14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17f6c48b09d5ff26f73918ef43ca06a1",
+    "content-hash": "2e1616fe198c2c943fa3e5a47bd57091",
     "packages": [
         {
             "name": "breerly/factory-girl-php",


### PR DESCRIPTION
This PR

* [x] removes an inappropriate `replace` configuration from `composer.json`

Follows #73.